### PR TITLE
Added test cases (#37)

### DIFF
--- a/src/main/java/com/techsophy/tsf/wrapperservice/config/TenantWorkflowResolver.java
+++ b/src/main/java/com/techsophy/tsf/wrapperservice/config/TenantWorkflowResolver.java
@@ -23,8 +23,7 @@ public class TenantWorkflowResolver {
     TokenUtils tokenUtils;
     public String getCamundaPathUri(String relativeUrl) {
         String tenant = tokenUtils.getIssuerFromToken(tokenUtils.getTokenFromContext());
-
-        return (Boolean.parseBoolean(sharedWorkflowEngine)||tenant.equals(defaultRealm))?
+        return (Boolean.parseBoolean(sharedWorkflowEngine)&&tenant.equals(defaultRealm))?
                 gatewayURI + camundaServletContextPath + relativeUrl:
                 gatewayURI + URL_SEPERATOR + tenant + camundaServletContextPath + relativeUrl;
 

--- a/src/test/java/com/techsophy/tsf/wrapperservice/config/TenantWorkflowResolverTest.java
+++ b/src/test/java/com/techsophy/tsf/wrapperservice/config/TenantWorkflowResolverTest.java
@@ -12,6 +12,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import static com.techsophy.tsf.wrapperservice.constants.MessageConstants.URL_SEPERATOR;
 import static org.mockito.Mockito.*;
 
 class TenantWorkflowResolverTest {
@@ -42,10 +43,9 @@ class TenantWorkflowResolverTest {
     @CsvSource({
             "false,techsophy-platform,/camunda",
             "true,techsophy-platform,/camunda",
-            "false,medunited,/medunited/camunda",
-            "true,medunited,/camunda"
+            "false,medunited,/camunda",
+            "true,medunited,/medunited/camunda"
     })
-
     void testAllServiceMethodsForSharedWorkflowEngine(String shared, String realm,String expectedFragment) {
 
         ReflectionTestUtils.setField(tenantWorkflowResolver,"sharedWorkflowEngine", shared);
@@ -54,7 +54,7 @@ class TenantWorkflowResolverTest {
 
         when(tokenUtils.getIssuerFromToken(anyString())).thenReturn(realm);
 
-        String expectedOutput = gatewayURI + expectedFragment + relativeUri;
+        String expectedOutput = shared.equals("true") ? gatewayURI + expectedFragment + relativeUri : gatewayURI + URL_SEPERATOR + realm + expectedFragment + relativeUri;
         String actualOutput = tenantWorkflowResolver.getCamundaPathUri(relativeUri);
         Assertions.assertEquals(expectedOutput, actualOutput);
     }


### PR DESCRIPTION
* Added test cases

* Update TenantWorkflowResolverTest.java

Added test cases and resolved issue where based on environment variable  share_db ,with value  true/false, a database is either shared among different tenants or different databases are created